### PR TITLE
Crash Fix : The view hierarchy is not prepared

### DIFF
--- a/MessageBanner/Classes/MBLMessageBanner.m
+++ b/MessageBanner/Classes/MBLMessageBanner.m
@@ -402,7 +402,16 @@ static struct delegateMethodsCaching {
                                                                                multiplier:1.0f
                                                                                  constant:0.0f]];
             } else {
-                if (realViewController.topLayoutGuide == nil && realViewController.navigationController.navigationBar != nil) {
+                if (![realViewController.view isDescendantOfView:viewController.view]) {
+                    [viewController.view addConstraint:[NSLayoutConstraint constraintWithItem:viewController.view
+                                                                                    attribute:NSLayoutAttributeTop
+                                                                                    relatedBy:NSLayoutRelationEqual
+                                                                                       toItem:message
+                                                                                    attribute:NSLayoutAttributeTop
+                                                                                   multiplier:1.0f
+                                                                                     constant:0.0f]];
+                }
+                else if (realViewController.topLayoutGuide == nil && realViewController.navigationController.navigationBar != nil) {
                     // This is a hack!!! iOS 9 the topLayoutGuide goes away and shows as nil in Reveal
                     [viewController.view addConstraint:[NSLayoutConstraint constraintWithItem:realViewController.navigationController.navigationBar
                                                                                     attribute:NSLayoutAttributeBottom


### PR DESCRIPTION
Fix Crash : The view hierarchy is not prepared for the constraint: <NSLayoutConstraint:0x15165cac0 _UILayoutSpacer:0x15161dd30'UIVC-topLayoutGuide'.bottom == MBLMessageBannerView:0x151620210.top>
This crashed appear when the realViewController.view is descendant of viewController when constraints are attached.

In my case, I call multiple message banners on the same navigationController but with different viewControllers. As attach constraints is called when the first banner is dismissed, the viewController still exist, but is not descendant of the navigationController any more. 
